### PR TITLE
Props rearranged to prevent loadRequest firing until all props ready.

### DIFF
--- a/WKWebView.ios.js
+++ b/WKWebView.ios.js
@@ -249,7 +249,6 @@ var WKWebView = React.createClass({
         ref={RCT_WEBVIEW_REF}
         key="webViewKey"
         style={webViewStyles}
-        source={resolveAssetSource(source)}
         injectedJavaScript={this.props.injectedJavaScript}
         bounces={this.props.bounces}
         scrollEnabled={this.props.scrollEnabled}
@@ -261,6 +260,7 @@ var WKWebView = React.createClass({
         onLoadingError={this._onLoadingError}
         onProgress={this._onProgress}
         onShouldStartLoadWithRequest={onShouldStartLoadWithRequest}
+        source={resolveAssetSource(source)}
       />;
 
     return (


### PR DESCRIPTION
I have discovered what `react-native` calls all the native setters depending on props order in JS. So `setSource` was called before `sendCookies` and other props ready. 
And because `setSource` calls `loadRequest` it was error with cookies, `_sendCookies` was false inside `loadRequest`.

I believe something changed with iOS 10/Xcode 8 and this error appeared.
